### PR TITLE
Fix calling `off` when no listeners are registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function createNamespaceEmitter () {
     if (event && fn) {
       var fns = this._fns[event]
       var i = 0
-      var l = fns.length
+      var l = fns ? fns.length : 0
 
       for (i; i < l; i++) {
         if (fns[i] !== fn) {

--- a/test.js
+++ b/test.js
@@ -52,6 +52,15 @@ test('remove all listeners of an event', function (t) {
   t.end()
 })
 
+test('remove when no listeners are registered', function (t) {
+  var emitter = createEmitter()
+
+  t.doesNotThrow(function () {
+    emitter.off('example', function () {})
+  })
+  t.end()
+})
+
 test('listen to all events', function (t) {
   var emitter = createEmitter()
   var count = 0


### PR DESCRIPTION
Calling `off` on an event with no listeners was causing a crash, because
namespace-emitter tried to access `fns.length` when `fns` was undefined.